### PR TITLE
Wled pixel art generator

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,9 @@ const state = {
   pixelColors: [],
   pixelPaletteIndexes: [],
   palette: [],
-  exportCache: ""
+  exportCache: "",
+  selectedColorKey: null,
+  selectedColor: null
 };
 
 const dom = {
@@ -24,6 +26,16 @@ const dom = {
   resolutionLabel: document.getElementById("resolutionLabel"),
   paletteControls: document.getElementById("paletteControls"),
   paletteSummary: document.getElementById("paletteSummary"),
+  selectionCount: document.getElementById("selectionCount"),
+  selectionPrompt: document.getElementById("selectionPrompt"),
+  selectionDetails: document.getElementById("selectionDetails"),
+  selectionSwatch: document.getElementById("selectionSwatch"),
+  selectionHex: document.getElementById("selectionHex"),
+  selectionPixels: document.getElementById("selectionPixels"),
+  paletteTarget: document.getElementById("paletteTarget"),
+  applyPaletteReplace: document.getElementById("applyPaletteReplace"),
+  customColor: document.getElementById("customColor"),
+  applyCustomReplace: document.getElementById("applyCustomReplace"),
   statusArea: document.getElementById("statusArea"),
   generateJson: document.getElementById("generateJson"),
   downloadJson: document.getElementById("downloadJson"),
@@ -77,6 +89,7 @@ function init() {
   initBlankGrid();
   wireEvents();
   renderAll();
+  updateSelectionUi();
   setStatus("Ready. Adjust settings or import an image to get started.");
 }
 
@@ -85,6 +98,7 @@ function initBlankGrid() {
   state.pixelColors = Array.from({ length: total }, () => [2, 6, 16]);
   state.palette = [[2, 6, 16]];
   state.pixelPaletteIndexes = Array(total).fill(0);
+  clearSelection();
 }
 
 function wireEvents() {
@@ -154,6 +168,9 @@ function wireEvents() {
     if (!dom.exportOutput.value) return;
     downloadJson(dom.exportOutput.value);
   });
+
+  dom.applyPaletteReplace.addEventListener("click", replaceColorWithPalette);
+  dom.applyCustomReplace.addEventListener("click", replaceColorWithCustom);
 }
 
 async function handleImageFile(file) {
@@ -188,6 +205,7 @@ function sampleImageToPixels(imageSource, targetWidth, targetHeight) {
 
 function applyPixels(pixels) {
   if (!pixels.length) return;
+  clearSelection();
   state.pixelColors = pixels.map(cloneColor);
   rebuildPaletteFromPixels();
   markExportDirty();
@@ -307,6 +325,7 @@ function colorDistance(a, b) {
 
 function resizeMatrix(newWidth, newHeight) {
   if (newWidth === state.width && newHeight === state.height) return;
+  clearSelection();
   const resized = resizePixelArray(state.pixelColors, state.width, state.height, newWidth, newHeight);
   state.width = newWidth;
   state.height = newHeight;
@@ -337,8 +356,7 @@ function markExportDirty() {
 function renderAll() {
   dom.matrixWidth.value = state.width;
   dom.matrixHeight.value = state.height;
-  dom.colorCount.value = state.paletteSize;
-  dom.colorCountValue.textContent = `${state.paletteSize} colors`;
+  syncPaletteSizeUi();
   dom.serpentineToggle.checked = state.serpentine;
   dom.resolutionLabel.textContent = `${state.width} × ${state.height}`;
   renderGrid();
@@ -355,11 +373,16 @@ function renderGrid() {
     pixel.className = "pixel";
     const color = state.pixelColors[i] ?? [0, 0, 0];
     pixel.style.background = rgbToCss(color);
+    if (state.selectedColorKey && rgbKey(color) === state.selectedColorKey) {
+      pixel.classList.add("selected");
+    }
     if (state.pixelPaletteIndexes[i] !== undefined) {
       const label = document.createElement("span");
-      label.textContent = (state.pixelPaletteIndexes[i] ?? 0) + 1;
+      const labelValue = state.pixelPaletteIndexes[i];
+      label.textContent = labelValue !== undefined ? labelValue + 1 : "";
       pixel.appendChild(label);
     }
+    pixel.addEventListener("click", () => selectColorByIndex(i));
     grid.appendChild(pixel);
   }
 }
@@ -373,6 +396,8 @@ function renderPaletteControls() {
     empty.className = "hint";
     empty.textContent = "No palette colors yet. Import an image or preset to begin.";
     dom.paletteControls.appendChild(empty);
+    populatePaletteSelect();
+    updateSelectionUi();
     return;
   }
   state.palette.forEach((color, idx) => {
@@ -398,6 +423,8 @@ function renderPaletteControls() {
     chip.append(colorInput, meta);
     dom.paletteControls.appendChild(chip);
   });
+  populatePaletteSelect();
+  updateSelectionUi();
 }
 
 function buildPaletteUsage() {
@@ -405,6 +432,176 @@ function buildPaletteUsage() {
     acc[idx] = (acc[idx] || 0) + 1;
     return acc;
   }, []);
+}
+
+function selectColorByIndex(index) {
+  const color = state.pixelColors[index];
+  if (!color) return;
+  state.selectedColor = cloneColor(color);
+  state.selectedColorKey = rgbKey(color);
+  const count = countSelectedPixels();
+  updateSelectionUi();
+  renderGrid();
+  setStatus(
+    `Selected ${rgbToHex(color)} covering ${count} pixel${count === 1 ? "" : "s"}.`
+  );
+}
+
+function updateSelectionUi() {
+  if (!dom.selectionDetails) return;
+  const hasSelection = Boolean(state.selectedColorKey && state.selectedColor);
+  dom.selectionDetails.classList.toggle("is-hidden", !hasSelection);
+  dom.selectionPrompt.classList.toggle("is-hidden", hasSelection);
+  dom.applyCustomReplace.disabled = !hasSelection;
+  dom.customColor.disabled = !hasSelection;
+  const hasPalette = state.palette.length > 0;
+  dom.paletteTarget.disabled = !hasPalette;
+  dom.applyPaletteReplace.disabled = !hasSelection || !hasPalette;
+
+  if (!hasSelection) {
+    dom.selectionCount.textContent = "No pixels selected";
+    dom.selectionPixels.textContent = "0 pixels";
+    return;
+  }
+
+  const count = countSelectedPixels();
+  dom.selectionCount.textContent = `${count} selected`;
+  dom.selectionPixels.textContent = `${count} pixel${count === 1 ? "" : "s"}`;
+  const color = state.selectedColor;
+  dom.selectionSwatch.style.background = rgbToCss(color);
+  dom.selectionHex.textContent = rgbToHex(color);
+}
+
+function populatePaletteSelect() {
+  if (!dom.paletteTarget) return;
+  const select = dom.paletteTarget;
+  const previousValue = select.value;
+  select.innerHTML = "";
+
+  if (!state.palette.length) {
+    const option = document.createElement("option");
+    option.textContent = "No palette colors available";
+    option.value = "";
+    option.disabled = true;
+    option.selected = true;
+    select.appendChild(option);
+    return;
+  }
+
+  state.palette.forEach((color, idx) => {
+    const option = document.createElement("option");
+    option.value = String(idx);
+    option.textContent = `#${idx + 1} ${rgbToHex(color)}`;
+    select.appendChild(option);
+  });
+
+  if (state.palette[Number(previousValue)]) {
+    select.value = previousValue;
+  } else {
+    select.selectedIndex = 0;
+  }
+}
+
+function countSelectedPixels() {
+  if (!state.selectedColorKey) return 0;
+  return state.pixelColors.reduce(
+    (acc, color) => (rgbKey(color) === state.selectedColorKey ? acc + 1 : acc),
+    0
+  );
+}
+
+function replaceColorWithPalette() {
+  if (!state.selectedColorKey) {
+    setStatus("Select a color in the grid first.", "warn");
+    return;
+  }
+  if (!state.palette.length) {
+    setStatus("No palette colors available yet.", "warn");
+    return;
+  }
+  const targetIndex = Number(dom.paletteTarget.value);
+  if (!Number.isInteger(targetIndex) || !state.palette[targetIndex]) {
+    setStatus("Choose a palette color to replace with.", "warn");
+    return;
+  }
+  const replaced = applyColorReplacement(targetIndex, state.palette[targetIndex]);
+  if (replaced === 0) {
+    setStatus("No pixels found for the selected color.", "warn");
+    return;
+  }
+  setStatus(
+    `Replaced ${replaced} pixel${replaced === 1 ? "" : "s"} with palette color ${
+      rgbToHex(state.palette[targetIndex])
+    }.`
+  );
+}
+
+function replaceColorWithCustom() {
+  if (!state.selectedColorKey) {
+    setStatus("Select a color in the grid first.", "warn");
+    return;
+  }
+  const hex = dom.customColor.value || "#ffffff";
+  const rgb = hexToRgb(hex);
+  const paletteIndex = ensurePaletteColor(rgb);
+  if (paletteIndex === -1) {
+    setStatus("Palette is full (32 colors). Remove a color before adding more.", "warn");
+    return;
+  }
+  const replaced = applyColorReplacement(paletteIndex, rgb);
+  if (replaced === 0) {
+    setStatus("No pixels found for the selected color.", "warn");
+    return;
+  }
+  setStatus(
+    `Replaced ${replaced} pixel${replaced === 1 ? "" : "s"} with ${rgbToHex(rgb)}.`
+  );
+}
+
+function ensurePaletteColor(color) {
+  const key = rgbKey(color);
+  const existingIndex = state.palette.findIndex((entry) => rgbKey(entry) === key);
+  if (existingIndex !== -1) {
+    return existingIndex;
+  }
+  if (state.palette.length >= 32) {
+    return -1;
+  }
+  state.palette.push(cloneColor(color));
+  state.paletteSize = Math.max(state.paletteSize, state.palette.length);
+  syncPaletteSizeUi();
+  return state.palette.length - 1;
+}
+
+function applyColorReplacement(paletteIndex, color) {
+  if (!state.pixelPaletteIndexes?.length) {
+    state.pixelPaletteIndexes = new Array(state.pixelColors.length).fill(0);
+  }
+  const nextColorKey = rgbKey(color);
+  let replaced = 0;
+  for (let i = 0; i < state.pixelColors.length; i += 1) {
+    if (rgbKey(state.pixelColors[i]) !== state.selectedColorKey) continue;
+    state.pixelPaletteIndexes[i] = paletteIndex;
+    state.pixelColors[i] = cloneColor(color);
+    replaced += 1;
+  }
+  if (replaced === 0) {
+    return 0;
+  }
+  state.selectedColor = cloneColor(color);
+  state.selectedColorKey = nextColorKey;
+  markExportDirty();
+  renderGrid();
+  renderPaletteControls();
+  return replaced;
+}
+
+function clearSelection() {
+  state.selectedColorKey = null;
+  state.selectedColor = null;
+  if (dom.selectionDetails) {
+    updateSelectionUi();
+  }
 }
 
 function loadPresetFromJson(raw) {
@@ -619,6 +816,11 @@ function hexToRgb(hex) {
   ];
 }
 
+function rgbKey(color) {
+  if (!color) return "";
+  return `${color[0] ?? 0},${color[1] ?? 0},${color[2] ?? 0}`;
+}
+
 function cloneColor(color) {
   return [
     clamp(Math.round(color?.[0] ?? 0), 0, 255),
@@ -654,4 +856,9 @@ function setStatus(message, level = "info") {
 
 function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max);
+}
+
+function syncPaletteSizeUi() {
+  dom.colorCount.value = state.paletteSize;
+  dom.colorCountValue.textContent = `${state.paletteSize} colors`;
 }

--- a/app.js
+++ b/app.js
@@ -8,7 +8,10 @@ const state = {
   palette: [],
   exportCache: "",
   selectedColorKey: null,
-  selectedColor: null
+  selectedColor: null,
+  paintMode: false,
+  paintColor: [255, 0, 0],
+  paintPaletteIndex: 0
 };
 
 const dom = {
@@ -36,6 +39,12 @@ const dom = {
   applyPaletteReplace: document.getElementById("applyPaletteReplace"),
   customColor: document.getElementById("customColor"),
   applyCustomReplace: document.getElementById("applyCustomReplace"),
+  paintPaletteTarget: document.getElementById("paintPaletteTarget"),
+  paintCustomColor: document.getElementById("paintCustomColor"),
+  setPaintCustom: document.getElementById("setPaintCustom"),
+  togglePaintMode: document.getElementById("togglePaintMode"),
+  paintSwatch: document.getElementById("paintSwatch"),
+  paintHex: document.getElementById("paintHex"),
   statusArea: document.getElementById("statusArea"),
   generateJson: document.getElementById("generateJson"),
   downloadJson: document.getElementById("downloadJson"),
@@ -90,6 +99,7 @@ function init() {
   wireEvents();
   renderAll();
   updateSelectionUi();
+  updatePaintUi();
   setStatus("Ready. Adjust settings or import an image to get started.");
 }
 
@@ -98,6 +108,9 @@ function initBlankGrid() {
   state.pixelColors = Array.from({ length: total }, () => [2, 6, 16]);
   state.palette = [[2, 6, 16]];
   state.pixelPaletteIndexes = Array(total).fill(0);
+  state.paintPaletteIndex = 0;
+  state.paintColor = cloneColor(state.palette[0]);
+  state.paintMode = false;
   clearSelection();
 }
 
@@ -171,6 +184,19 @@ function wireEvents() {
 
   dom.applyPaletteReplace.addEventListener("click", replaceColorWithPalette);
   dom.applyCustomReplace.addEventListener("click", replaceColorWithCustom);
+  if (dom.paintPaletteTarget) {
+    dom.paintPaletteTarget.addEventListener("change", () => {
+      setPaintColorFromPalette(Number(dom.paintPaletteTarget.value));
+    });
+  }
+  if (dom.setPaintCustom) {
+    dom.setPaintCustom.addEventListener("click", () => {
+      setPaintColorFromCustom(dom.paintCustomColor.value);
+    });
+  }
+  if (dom.togglePaintMode) {
+    dom.togglePaintMode.addEventListener("click", togglePaintMode);
+  }
 }
 
 async function handleImageFile(file) {
@@ -382,9 +408,27 @@ function renderGrid() {
       label.textContent = labelValue !== undefined ? labelValue + 1 : "";
       pixel.appendChild(label);
     }
-    pixel.addEventListener("click", () => selectColorByIndex(i));
+    pixel.addEventListener("click", (event) => handlePixelClick(event, i));
     grid.appendChild(pixel);
   }
+}
+
+function handlePixelClick(event, index) {
+  if (shouldPaint(event)) {
+    paintPixel(index);
+  } else {
+    selectColorByIndex(index);
+  }
+}
+
+function shouldPaint(event) {
+  return Boolean(
+    state.paintMode ||
+      event?.metaKey ||
+      event?.ctrlKey ||
+      event?.altKey ||
+      event?.shiftKey
+  );
 }
 
 function renderPaletteControls() {
@@ -396,8 +440,9 @@ function renderPaletteControls() {
     empty.className = "hint";
     empty.textContent = "No palette colors yet. Import an image or preset to begin.";
     dom.paletteControls.appendChild(empty);
-    populatePaletteSelect();
+    populatePaletteSelects();
     updateSelectionUi();
+    updatePaintUi();
     return;
   }
   state.palette.forEach((color, idx) => {
@@ -413,6 +458,7 @@ function renderPaletteControls() {
       state.pixelColors = state.pixelPaletteIndexes.map((assignment) => state.palette[assignment] || [0, 0, 0]);
       markExportDirty();
       renderGrid();
+      updatePaintUi();
     });
 
     const meta = document.createElement("div");
@@ -423,8 +469,9 @@ function renderPaletteControls() {
     chip.append(colorInput, meta);
     dom.paletteControls.appendChild(chip);
   });
-  populatePaletteSelect();
+  populatePaletteSelects();
   updateSelectionUi();
+  updatePaintUi();
 }
 
 function buildPaletteUsage() {
@@ -472,11 +519,25 @@ function updateSelectionUi() {
   dom.selectionHex.textContent = rgbToHex(color);
 }
 
-function populatePaletteSelect() {
-  if (!dom.paletteTarget) return;
-  const select = dom.paletteTarget;
-  const previousValue = select.value;
-  select.innerHTML = "";
+function populatePaletteSelects() {
+  populatePaletteSelect(dom.paletteTarget);
+  populatePaletteSelect(dom.paintPaletteTarget, state.paintPaletteIndex);
+  if (state.palette.length && dom.paintPaletteTarget && dom.paintPaletteTarget.value !== "") {
+    const idx = Number(dom.paintPaletteTarget.value);
+    if (Number.isInteger(idx) && state.palette[idx]) {
+      state.paintPaletteIndex = idx;
+      state.paintColor = cloneColor(state.palette[idx]);
+    }
+  }
+}
+
+function populatePaletteSelect(selectElement, preferredValue) {
+  if (!selectElement) return;
+  const previousValue =
+    preferredValue !== undefined && preferredValue !== null
+      ? String(preferredValue)
+      : selectElement.value;
+  selectElement.innerHTML = "";
 
   if (!state.palette.length) {
     const option = document.createElement("option");
@@ -484,7 +545,8 @@ function populatePaletteSelect() {
     option.value = "";
     option.disabled = true;
     option.selected = true;
-    select.appendChild(option);
+    selectElement.appendChild(option);
+    selectElement.disabled = true;
     return;
   }
 
@@ -492,13 +554,78 @@ function populatePaletteSelect() {
     const option = document.createElement("option");
     option.value = String(idx);
     option.textContent = `#${idx + 1} ${rgbToHex(color)}`;
-    select.appendChild(option);
+    selectElement.appendChild(option);
   });
 
-  if (state.palette[Number(previousValue)]) {
-    select.value = previousValue;
+  if (state.palette[Number(previousValue)] !== undefined) {
+    selectElement.value = String(previousValue);
   } else {
-    select.selectedIndex = 0;
+    selectElement.selectedIndex = 0;
+  }
+  selectElement.disabled = false;
+}
+
+function setPaintColorFromPalette(index) {
+  if (!state.palette.length) {
+    setStatus("No palette colors available yet.", "warn");
+    return;
+  }
+  const safeIndex = Number.isInteger(index) && state.palette[index] ? index : 0;
+  state.paintPaletteIndex = safeIndex;
+  state.paintColor = cloneColor(state.palette[safeIndex]);
+  if (dom.paintPaletteTarget) {
+    dom.paintPaletteTarget.value = String(safeIndex);
+  }
+  updatePaintUi();
+  setStatus(`Painting with palette color ${rgbToHex(state.paintColor)}.`);
+}
+
+function setPaintColorFromCustom(hex) {
+  const color = hexToRgb(hex || "#ffffff");
+  const paletteIndex = ensurePaletteColor(color);
+  if (paletteIndex === -1) {
+    setStatus("Palette is full (32 colors). Remove a color before adding more.", "warn");
+    return;
+  }
+  state.paintPaletteIndex = paletteIndex;
+  state.paintColor = cloneColor(state.palette[paletteIndex]);
+  renderPaletteControls();
+  setStatus(`Added ${rgbToHex(color)} for painting.`);
+}
+
+function togglePaintMode() {
+  state.paintMode = !state.paintMode;
+  updatePaintUi();
+  setStatus(state.paintMode ? "Paint mode enabled." : "Paint mode disabled.");
+}
+
+function updatePaintUi() {
+  if (!dom.paintSwatch || !dom.paintHex) return;
+  if (!state.palette.length) {
+    dom.paintSwatch.style.background = "#000000";
+    dom.paintHex.textContent = "#000000";
+    if (dom.togglePaintMode) {
+      dom.togglePaintMode.disabled = true;
+      dom.togglePaintMode.classList.remove("is-active");
+      dom.togglePaintMode.textContent = "Paint mode off";
+    }
+    return;
+  }
+  const index =
+    Number.isInteger(state.paintPaletteIndex) && state.palette[state.paintPaletteIndex]
+      ? state.paintPaletteIndex
+      : 0;
+  state.paintPaletteIndex = index;
+  state.paintColor = cloneColor(state.palette[index]);
+  dom.paintSwatch.style.background = rgbToCss(state.paintColor);
+  dom.paintHex.textContent = rgbToHex(state.paintColor);
+  if (dom.paintPaletteTarget) {
+    dom.paintPaletteTarget.value = String(index);
+  }
+  if (dom.togglePaintMode) {
+    dom.togglePaintMode.disabled = false;
+    dom.togglePaintMode.classList.toggle("is-active", state.paintMode);
+    dom.togglePaintMode.textContent = state.paintMode ? "Paint mode on" : "Paint mode off";
   }
 }
 
@@ -556,6 +683,26 @@ function replaceColorWithCustom() {
   setStatus(
     `Replaced ${replaced} pixel${replaced === 1 ? "" : "s"} with ${rgbToHex(rgb)}.`
   );
+}
+
+function paintPixel(index) {
+  const paletteIndex = ensurePaletteColor(state.paintColor);
+  if (paletteIndex === -1) {
+    setStatus("Palette is full (32 colors). Remove a color before adding more.", "warn");
+    return;
+  }
+  state.paintPaletteIndex = paletteIndex;
+  const color = cloneColor(state.palette[paletteIndex]);
+  state.paintColor = cloneColor(color);
+  if (!state.pixelPaletteIndexes?.length) {
+    state.pixelPaletteIndexes = new Array(state.pixelColors.length).fill(0);
+  }
+  state.pixelPaletteIndexes[index] = paletteIndex;
+  state.pixelColors[index] = cloneColor(color);
+  markExportDirty();
+  renderGrid();
+  renderPaletteControls();
+  setStatus(`Painted pixel ${index + 1} with ${rgbToHex(color)}.`);
 }
 
 function ensurePaletteColor(color) {

--- a/app.js
+++ b/app.js
@@ -1,0 +1,657 @@
+const state = {
+  width: 17,
+  height: 17,
+  paletteSize: 8,
+  serpentine: true,
+  pixelColors: [],
+  pixelPaletteIndexes: [],
+  palette: [],
+  exportCache: ""
+};
+
+const dom = {
+  matrixWidth: document.getElementById("matrixWidth"),
+  matrixHeight: document.getElementById("matrixHeight"),
+  colorCount: document.getElementById("colorCount"),
+  colorCountValue: document.getElementById("colorCountValue"),
+  serpentineToggle: document.getElementById("serpentineOrder"),
+  resetGrid: document.getElementById("resetGrid"),
+  imageInput: document.getElementById("imageInput"),
+  jsonInput: document.getElementById("jsonInput"),
+  loadJson: document.getElementById("loadJson"),
+  sampleJson: document.getElementById("sampleJson"),
+  previewGrid: document.getElementById("preview-grid"),
+  resolutionLabel: document.getElementById("resolutionLabel"),
+  paletteControls: document.getElementById("paletteControls"),
+  paletteSummary: document.getElementById("paletteSummary"),
+  statusArea: document.getElementById("statusArea"),
+  generateJson: document.getElementById("generateJson"),
+  downloadJson: document.getElementById("downloadJson"),
+  exportOutput: document.getElementById("exportOutput"),
+  workCanvas: document.getElementById("workCanvas")
+};
+
+const SAMPLE_PRESET = JSON.stringify(
+  {
+    name: "Sample 8-bit Heart",
+    on: true,
+    bri: 200,
+    mainseg: 0,
+    meta: {
+      generator: "sample",
+      matrix: { width: 17, height: 17, serpentine: true }
+    },
+    palette: [
+      [8, 10, 22],
+      [219, 39, 119],
+      [244, 114, 182],
+      [252, 231, 243]
+    ],
+    pixels: [
+      0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,
+      0,0,0,0,0,0,0,1,2,1,0,0,0,0,0,0,0,
+      0,0,0,0,0,0,1,2,3,2,1,0,0,0,0,0,0,
+      0,0,0,0,0,1,2,3,3,3,2,1,0,0,0,0,0,
+      0,0,0,0,1,2,3,3,3,3,3,2,1,0,0,0,0,
+      0,0,0,1,2,3,3,3,3,3,3,3,2,1,0,0,0,
+      0,0,1,2,3,3,3,3,3,3,3,3,3,2,1,0,0,
+      0,0,1,2,3,3,3,3,3,3,3,3,3,2,1,0,0,
+      0,0,0,1,2,3,3,3,3,3,3,3,2,1,0,0,0,
+      0,0,0,0,1,2,3,3,3,3,3,2,1,0,0,0,0,
+      0,0,0,0,0,1,2,3,3,3,2,1,0,0,0,0,0,
+      0,0,0,0,0,0,1,2,3,2,1,0,0,0,0,0,0,
+      0,0,0,0,0,0,0,1,2,1,0,0,0,0,0,0,0,
+      0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,
+      0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+      0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+      0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+    ]
+  },
+  null,
+  2
+);
+
+document.addEventListener("DOMContentLoaded", init);
+
+function init() {
+  initBlankGrid();
+  wireEvents();
+  renderAll();
+  setStatus("Ready. Adjust settings or import an image to get started.");
+}
+
+function initBlankGrid() {
+  const total = state.width * state.height;
+  state.pixelColors = Array.from({ length: total }, () => [2, 6, 16]);
+  state.palette = [[2, 6, 16]];
+  state.pixelPaletteIndexes = Array(total).fill(0);
+}
+
+function wireEvents() {
+  dom.matrixWidth.addEventListener("change", () => {
+    const value = clamp(parseInt(dom.matrixWidth.value, 10) || 1, 1, 64);
+    dom.matrixWidth.value = value;
+    resizeMatrix(value, state.height);
+  });
+
+  dom.matrixHeight.addEventListener("change", () => {
+    const value = clamp(parseInt(dom.matrixHeight.value, 10) || 1, 1, 64);
+    dom.matrixHeight.value = value;
+    resizeMatrix(state.width, value);
+  });
+
+  dom.colorCount.addEventListener("input", () => {
+    const value = clamp(parseInt(dom.colorCount.value, 10) || 2, 2, 32);
+    state.paletteSize = value;
+    dom.colorCountValue.textContent = `${value} colors`;
+    rebuildPaletteFromPixels();
+    markExportDirty();
+    renderAll();
+  });
+
+  dom.serpentineToggle.addEventListener("change", () => {
+    state.serpentine = dom.serpentineToggle.checked;
+    markExportDirty();
+    renderGrid();
+  });
+
+  dom.resetGrid.addEventListener("click", () => {
+    initBlankGrid();
+    rebuildPaletteFromPixels();
+    renderAll();
+    setStatus("Grid reset to blank state.");
+  });
+
+  dom.imageInput.addEventListener("change", async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    await handleImageFile(file);
+    dom.imageInput.value = "";
+  });
+
+  dom.loadJson.addEventListener("click", () => {
+    const raw = dom.jsonInput.value.trim();
+    if (!raw) {
+      setStatus("Paste a JSON payload before loading.", "warn");
+      return;
+    }
+    loadPresetFromJson(raw);
+  });
+
+  dom.sampleJson.addEventListener("click", () => {
+    dom.jsonInput.value = SAMPLE_PRESET;
+    loadPresetFromJson(SAMPLE_PRESET);
+  });
+
+  dom.generateJson.addEventListener("click", () => {
+    const json = buildWledPresetJson();
+    dom.exportOutput.value = json;
+    dom.downloadJson.disabled = false;
+    setStatus("Preset JSON generated. Download or copy it into presets.json.");
+  });
+
+  dom.downloadJson.addEventListener("click", () => {
+    if (!dom.exportOutput.value) return;
+    downloadJson(dom.exportOutput.value);
+  });
+}
+
+async function handleImageFile(file) {
+  try {
+    const imageSource = await decodeImageFile(file);
+    const pixels = sampleImageToPixels(imageSource, state.width, state.height);
+    if (typeof imageSource.close === "function") {
+      imageSource.close();
+    }
+    applyPixels(pixels);
+    setStatus(`Loaded ${file.name} and reduced to ${state.width}×${state.height}.`);
+  } catch (error) {
+    console.error(error);
+    setStatus("Failed to decode image. Try a different file.", "error");
+  }
+}
+
+function sampleImageToPixels(imageSource, targetWidth, targetHeight) {
+  const canvas = dom.workCanvas;
+  canvas.width = targetWidth;
+  canvas.height = targetHeight;
+  const ctx = canvas.getContext("2d", { willReadFrequently: true });
+  ctx.clearRect(0, 0, targetWidth, targetHeight);
+  ctx.drawImage(imageSource, 0, 0, targetWidth, targetHeight);
+  const { data } = ctx.getImageData(0, 0, targetWidth, targetHeight);
+  const pixels = [];
+  for (let i = 0; i < data.length; i += 4) {
+    pixels.push([data[i], data[i + 1], data[i + 2]]);
+  }
+  return pixels;
+}
+
+function applyPixels(pixels) {
+  if (!pixels.length) return;
+  state.pixelColors = pixels.map(cloneColor);
+  rebuildPaletteFromPixels();
+  markExportDirty();
+  renderAll();
+}
+
+function rebuildPaletteFromPixels() {
+  if (!state.pixelColors.length) return;
+  const { palette, assignments } = quantizeColors(state.pixelColors, clamp(state.paletteSize, 2, 32));
+  state.palette = palette;
+  state.pixelPaletteIndexes = assignments.length
+    ? assignments
+    : new Array(state.pixelColors.length).fill(0);
+  state.pixelColors = state.pixelPaletteIndexes.map((idx) => palette[idx] ?? [0, 0, 0]);
+}
+
+function quantizeColors(pixels, targetCount) {
+  if (!pixels.length) {
+    return { palette: [[0, 0, 0]], assignments: [] };
+  }
+  const deduped = uniqueColors(pixels);
+  if (deduped.length <= targetCount) {
+    const palette = deduped;
+    const paletteMap = new Map(palette.map((color, idx) => [color.join(","), idx]));
+    const assignments = pixels.map((pixel) => {
+      const key = pixel.join(",");
+      return paletteMap.has(key) ? paletteMap.get(key) : 0;
+    });
+    return { palette, assignments };
+  }
+
+  const centroids = initCentroids(pixels, targetCount);
+  const assignments = new Array(pixels.length).fill(0);
+  const sums = centroids.map(() => ({ r: 0, g: 0, b: 0, count: 0 }));
+
+  for (let iteration = 0; iteration < 12; iteration += 1) {
+    let moved = 0;
+    sums.forEach((sum) => {
+      sum.r = 0;
+      sum.g = 0;
+      sum.b = 0;
+      sum.count = 0;
+    });
+
+    for (let i = 0; i < pixels.length; i += 1) {
+      const pixel = pixels[i];
+      let bestIdx = 0;
+      let bestDist = Infinity;
+      for (let c = 0; c < centroids.length; c += 1) {
+        const dist = colorDistance(pixel, centroids[c]);
+        if (dist < bestDist) {
+          bestDist = dist;
+          bestIdx = c;
+        }
+      }
+      if (assignments[i] !== bestIdx) {
+        assignments[i] = bestIdx;
+        moved += 1;
+      }
+      const sum = sums[bestIdx];
+      sum.r += pixel[0];
+      sum.g += pixel[1];
+      sum.b += pixel[2];
+      sum.count += 1;
+    }
+
+    for (let c = 0; c < centroids.length; c += 1) {
+      const sum = sums[c];
+      if (sum.count === 0) {
+        centroids[c] = [...pixels[Math.floor(Math.random() * pixels.length)]];
+      } else {
+        centroids[c] = [
+          Math.round(sum.r / sum.count),
+          Math.round(sum.g / sum.count),
+          Math.round(sum.b / sum.count)
+        ];
+      }
+    }
+
+    if (moved === 0) break;
+  }
+
+  return { palette: centroids, assignments };
+}
+
+function uniqueColors(pixels) {
+  const seen = new Map();
+  const palette = [];
+  pixels.forEach((pixel) => {
+    const key = pixel.join(",");
+    if (!seen.has(key)) {
+      seen.set(key, true);
+      palette.push(cloneColor(pixel));
+    }
+  });
+  return palette;
+}
+
+function initCentroids(pixels, count) {
+  const centroids = [];
+  const taken = new Set();
+  while (centroids.length < count) {
+    const idx = Math.floor(Math.random() * pixels.length);
+    if (taken.has(idx)) continue;
+    taken.add(idx);
+    centroids.push([...pixels[idx]]);
+  }
+  return centroids;
+}
+
+function colorDistance(a, b) {
+  const dr = a[0] - b[0];
+  const dg = a[1] - b[1];
+  const db = a[2] - b[2];
+  return dr * dr + dg * dg + db * db;
+}
+
+function resizeMatrix(newWidth, newHeight) {
+  if (newWidth === state.width && newHeight === state.height) return;
+  const resized = resizePixelArray(state.pixelColors, state.width, state.height, newWidth, newHeight);
+  state.width = newWidth;
+  state.height = newHeight;
+  state.pixelColors = resized;
+  rebuildPaletteFromPixels();
+  markExportDirty();
+  renderAll();
+}
+
+function resizePixelArray(pixels, oldWidth, oldHeight, newWidth, newHeight) {
+  const result = [];
+  for (let y = 0; y < newHeight; y += 1) {
+    for (let x = 0; x < newWidth; x += 1) {
+      const srcX = Math.min(oldWidth - 1, Math.floor((x / newWidth) * oldWidth));
+      const srcY = Math.min(oldHeight - 1, Math.floor((y / newHeight) * oldHeight));
+      result.push([...pixels[srcY * oldWidth + srcX] || [0, 0, 0]]);
+    }
+  }
+  return result;
+}
+
+function markExportDirty() {
+  state.exportCache = "";
+  dom.exportOutput.value = "";
+  dom.downloadJson.disabled = true;
+}
+
+function renderAll() {
+  dom.matrixWidth.value = state.width;
+  dom.matrixHeight.value = state.height;
+  dom.colorCount.value = state.paletteSize;
+  dom.colorCountValue.textContent = `${state.paletteSize} colors`;
+  dom.serpentineToggle.checked = state.serpentine;
+  dom.resolutionLabel.textContent = `${state.width} × ${state.height}`;
+  renderGrid();
+  renderPaletteControls();
+}
+
+function renderGrid() {
+  const total = state.width * state.height;
+  const grid = dom.previewGrid;
+  grid.style.gridTemplateColumns = `repeat(${state.width}, 1fr)`;
+  grid.innerHTML = "";
+  for (let i = 0; i < total; i += 1) {
+    const pixel = document.createElement("div");
+    pixel.className = "pixel";
+    const color = state.pixelColors[i] ?? [0, 0, 0];
+    pixel.style.background = rgbToCss(color);
+    if (state.pixelPaletteIndexes[i] !== undefined) {
+      const label = document.createElement("span");
+      label.textContent = (state.pixelPaletteIndexes[i] ?? 0) + 1;
+      pixel.appendChild(label);
+    }
+    grid.appendChild(pixel);
+  }
+}
+
+function renderPaletteControls() {
+  const usage = buildPaletteUsage();
+  dom.paletteSummary.textContent = `${state.palette.length} colors`;
+  dom.paletteControls.innerHTML = "";
+  if (!state.palette.length) {
+    const empty = document.createElement("p");
+    empty.className = "hint";
+    empty.textContent = "No palette colors yet. Import an image or preset to begin.";
+    dom.paletteControls.appendChild(empty);
+    return;
+  }
+  state.palette.forEach((color, idx) => {
+    const chip = document.createElement("div");
+    chip.className = "palette-chip";
+
+    const colorInput = document.createElement("input");
+    colorInput.type = "color";
+    colorInput.value = rgbToHex(color);
+    colorInput.addEventListener("input", (event) => {
+      const nextColor = hexToRgb(event.target.value);
+      state.palette[idx] = nextColor;
+      state.pixelColors = state.pixelPaletteIndexes.map((assignment) => state.palette[assignment] || [0, 0, 0]);
+      markExportDirty();
+      renderGrid();
+    });
+
+    const meta = document.createElement("div");
+    meta.className = "palette-meta";
+    const hex = rgbToHex(color);
+    meta.innerHTML = `<strong>#${idx + 1} ${hex}</strong><span>${usage[idx] || 0} pixels</span>`;
+
+    chip.append(colorInput, meta);
+    dom.paletteControls.appendChild(chip);
+  });
+}
+
+function buildPaletteUsage() {
+  return state.pixelPaletteIndexes.reduce((acc, idx) => {
+    acc[idx] = (acc[idx] || 0) + 1;
+    return acc;
+  }, []);
+}
+
+function loadPresetFromJson(raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    const preset = normalizePreset(parsed);
+    if (!preset) {
+      setStatus("Unable to interpret JSON payload.", "error");
+      return;
+    }
+    state.width = preset.width;
+    state.height = preset.height;
+    state.serpentine = preset.serpentine;
+    const uniqueColors = new Set(preset.pixelColors.map((color) => color.join(",")));
+    state.paletteSize = clamp(
+      Math.max(state.paletteSize, uniqueColors.size || state.paletteSize),
+      2,
+      32
+    );
+    applyPixels(preset.pixelColors);
+    renderAll();
+    setStatus("Preset loaded. Adjust palette or export when ready.");
+  } catch (error) {
+    console.error(error);
+    setStatus("Invalid JSON supplied.", "error");
+  }
+}
+
+function normalizePreset(input) {
+  const seg = Array.isArray(input.seg) ? input.seg[0] : undefined;
+  const total =
+    (seg ? (seg.stop ?? 0) - (seg.start ?? 0) : 0) ||
+    (Array.isArray(input.pixels) ? input.pixels.length : 0) ||
+    state.width * state.height;
+  const metaMatrix = input.meta?.matrix;
+  const width = clamp(parseInt(metaMatrix?.width, 10) || inferWidth(total) || state.width, 1, 64);
+  const height = clamp(parseInt(metaMatrix?.height, 10) || inferHeight(total, width) || state.height, 1, 64);
+  const serpentine = typeof metaMatrix?.serpentine === "boolean" ? metaMatrix.serpentine : state.serpentine;
+
+  let pixels = [];
+  const paletteArray = Array.isArray(input.palette)
+    ? input.palette.map(coerceColor).filter(Boolean)
+    : [];
+
+  if (Array.isArray(input.pixels) && paletteArray.length) {
+    if (typeof input.pixels[0] === "number") {
+      pixels = input.pixels.map((paletteIndex) => paletteArray[paletteIndex] ?? [0, 0, 0]);
+    } else if (Array.isArray(input.pixels[0])) {
+      pixels = input.pixels.map((color) => coerceColor(color) ?? [0, 0, 0]);
+    }
+  } else if (Array.isArray(input.pixelColors)) {
+    pixels = input.pixelColors.map((color) => coerceColor(color) ?? [0, 0, 0]);
+  } else if (seg?.i) {
+    const ledCount = Math.max(total || width * height, width * height);
+    const ledColors = new Array(ledCount).fill([0, 0, 0]);
+    const entries = seg.i;
+    for (let i = 0; i < entries.length; i += 2) {
+      const ledIndex = Number(entries[i]);
+      const color = coerceColor(entries[i + 1]);
+      if (!color) continue;
+      if (ledIndex >= 0 && ledIndex < ledColors.length) {
+        ledColors[ledIndex] = color;
+      }
+    }
+    pixels = fromLedOrder(ledColors, width, height, serpentine);
+  }
+
+  if (!pixels.length) return null;
+  const sourceWidth = width;
+  const sourceHeight = Math.ceil(pixels.length / sourceWidth) || height;
+  if (pixels.length !== width * height) {
+    pixels = resizePixelArray(pixels, sourceWidth, sourceHeight, width, height);
+  }
+  return { width, height, serpentine, pixelColors: pixels };
+}
+
+function fromLedOrder(ledColors, width, height, serpentine) {
+  const pixels = new Array(width * height).fill([0, 0, 0]);
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const ledIndex = linearIndex(x, y, width, serpentine);
+      pixels[y * width + x] = cloneColor(ledColors[ledIndex] ?? [0, 0, 0]);
+    }
+  }
+  return pixels;
+}
+
+function linearIndex(x, y, width, serpentine) {
+  if (serpentine && y % 2 === 1) {
+    return y * width + (width - 1 - x);
+  }
+  return y * width + x;
+}
+
+function buildLedList() {
+  const ledCount = state.width * state.height;
+  const ledColors = new Array(ledCount).fill([0, 0, 0]);
+  for (let y = 0; y < state.height; y += 1) {
+    for (let x = 0; x < state.width; x += 1) {
+      const matrixIndex = y * state.width + x;
+      const ledIndex = linearIndex(x, y, state.width, state.serpentine);
+      ledColors[ledIndex] = cloneColor(state.pixelColors[matrixIndex] ?? [0, 0, 0]);
+    }
+  }
+  const iArray = [];
+  ledColors.forEach((color, idx) => {
+    iArray.push(idx, color.map((value) => clamp(Math.round(value), 0, 255)));
+  });
+  return iArray;
+}
+
+function buildWledPresetJson() {
+  const ledCount = state.width * state.height;
+  const payload = {
+    name: `Matrix ${state.width}x${state.height}`,
+    on: true,
+    bri: 255,
+    transition: 7,
+    mainseg: 0,
+    seg: [
+      {
+        id: 0,
+        start: 0,
+        stop: ledCount,
+        grp: 1,
+        of: 0,
+        on: true,
+        bri: 255,
+        i: buildLedList()
+      }
+    ],
+    palette: state.palette,
+    pixels: state.pixelPaletteIndexes,
+    meta: {
+      generator: "wled-pixel-art-generator",
+      generatedAt: new Date().toISOString(),
+      matrix: {
+        width: state.width,
+        height: state.height,
+        serpentine: state.serpentine
+      }
+    }
+  };
+  state.exportCache = JSON.stringify(payload, null, 2);
+  return state.exportCache;
+}
+
+function downloadJson(content) {
+  const blob = new Blob([content], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = `wled-pixel-art-${state.width}x${state.height}.json`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+  setStatus("JSON downloaded. Copy it into presets.json or upload via WLED UI.");
+}
+
+function decodeImageFile(file) {
+  if (window.createImageBitmap) {
+    return createImageBitmap(file);
+  }
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    const url = URL.createObjectURL(file);
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(img);
+    };
+    img.onerror = (error) => {
+      URL.revokeObjectURL(url);
+      reject(error);
+    };
+    img.src = url;
+  });
+}
+
+function inferWidth(total) {
+  if (!total) return state.width;
+  const sqrt = Math.round(Math.sqrt(total));
+  if (sqrt * sqrt === total) return sqrt;
+  return Math.min(Math.max(1, total / state.height), 64);
+}
+
+function inferHeight(total, width) {
+  if (!total) return state.height;
+  return Math.min(64, Math.max(1, Math.round(total / width)));
+}
+
+function rgbToCss(color) {
+  return `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
+}
+
+function rgbToHex(color) {
+  return `#${color.map((value) => value.toString(16).padStart(2, "0")).join("")}`;
+}
+
+function hexToRgb(hex) {
+  let parsed = hex.replace("#", "");
+  if (parsed.length === 3) {
+    parsed = parsed
+      .split("")
+      .map((ch) => ch + ch)
+      .join("");
+  }
+  return [
+    parseInt(parsed.slice(0, 2), 16),
+    parseInt(parsed.slice(2, 4), 16),
+    parseInt(parsed.slice(4, 6), 16)
+  ];
+}
+
+function cloneColor(color) {
+  return [
+    clamp(Math.round(color?.[0] ?? 0), 0, 255),
+    clamp(Math.round(color?.[1] ?? 0), 0, 255),
+    clamp(Math.round(color?.[2] ?? 0), 0, 255)
+  ];
+}
+
+function coerceColor(input) {
+  if (Array.isArray(input)) {
+    return cloneColor(input);
+  }
+  if (typeof input === "string") {
+    const trimmed = input.trim().replace(/^0x/i, "");
+    if (/^[0-9a-fA-F]{6}$/.test(trimmed)) {
+      return hexToRgb(`#${trimmed}`);
+    }
+  }
+  if (typeof input === "number" && Number.isFinite(input)) {
+    return [
+      clamp((input >> 16) & 0xff, 0, 255),
+      clamp((input >> 8) & 0xff, 0, 255),
+      clamp(input & 0xff, 0, 255)
+    ];
+  }
+  return null;
+}
+
+function setStatus(message, level = "info") {
+  dom.statusArea.textContent = message;
+  dom.statusArea.dataset.level = level;
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}

--- a/app.js
+++ b/app.js
@@ -11,7 +11,9 @@ const state = {
   selectedColor: null,
   paintMode: false,
   paintColor: [255, 0, 0],
-  paintPaletteIndex: 0
+  paintPaletteIndex: 0,
+  touchTimerId: null,
+  touchLongPressTriggered: false
 };
 
 const dom = {
@@ -409,16 +411,20 @@ function renderGrid() {
       pixel.appendChild(label);
     }
     pixel.addEventListener("click", (event) => handlePixelClick(event, i));
+    pixel.addEventListener("touchstart", (event) => handleTouchStart(event, i), {
+      passive: false
+    });
+    pixel.addEventListener("touchend", (event) => handleTouchEnd(event, i), {
+      passive: false
+    });
+    pixel.addEventListener("touchmove", clearTouchLongPress, { passive: true });
+    pixel.addEventListener("touchcancel", clearTouchLongPress, { passive: true });
     grid.appendChild(pixel);
   }
 }
 
 function handlePixelClick(event, index) {
-  if (shouldPaint(event)) {
-    paintPixel(index);
-  } else {
-    selectColorByIndex(index);
-  }
+  performPixelAction(index, shouldPaint(event));
 }
 
 function shouldPaint(event) {
@@ -429,6 +435,14 @@ function shouldPaint(event) {
       event?.altKey ||
       event?.shiftKey
   );
+}
+
+function performPixelAction(index, paint) {
+  if (paint) {
+    paintPixel(index);
+  } else {
+    selectColorByIndex(index);
+  }
 }
 
 function renderPaletteControls() {
@@ -703,6 +717,43 @@ function paintPixel(index) {
   renderGrid();
   renderPaletteControls();
   setStatus(`Painted pixel ${index + 1} with ${rgbToHex(color)}.`);
+}
+
+function handleTouchStart(event, index) {
+  if (event.touches.length > 1) return;
+  clearTouchLongPress();
+  state.touchLongPressTriggered = false;
+  if (state.paintMode) {
+    event.preventDefault();
+  }
+  state.touchTimerId = window.setTimeout(() => {
+    state.touchTimerId = null;
+    state.touchLongPressTriggered = true;
+    paintPixel(index);
+  }, 500);
+}
+
+function handleTouchEnd(event, index) {
+  if (event.changedTouches.length > 1) return;
+  if (state.touchTimerId) {
+    clearTimeout(state.touchTimerId);
+    state.touchTimerId = null;
+  }
+  if (state.touchLongPressTriggered) {
+    state.touchLongPressTriggered = false;
+    event.preventDefault();
+    return;
+  }
+  event.preventDefault();
+  performPixelAction(index, state.paintMode);
+}
+
+function clearTouchLongPress() {
+  if (state.touchTimerId) {
+    clearTimeout(state.touchTimerId);
+    state.touchTimerId = null;
+  }
+  state.touchLongPressTriggered = false;
 }
 
 function ensurePaletteColor(color) {

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
           <span id="selectionCount">No pixels selected</span>
         </div>
         <p id="selectionPrompt" class="hint">
-          Click any pixel in the preview grid to select its color.
+          Tap or click any pixel to select its color. Long-press (touch) or enable paint mode to paint individual squares.
         </p>
         <div id="selectionDetails" class="selection-details is-hidden">
           <div class="selection-row">
@@ -116,7 +116,7 @@
             <button id="togglePaintMode" class="ghost small" type="button">Paint mode off</button>
           </div>
           <p class="hint">
-            Choose a paint color, then click pixels while paint mode is on (or hold Ctrl/Cmd while clicking).
+            Choose a paint color, then tap/click pixels while paint mode is on. Desktop shortcut: hold Ctrl/Cmd (or Shift) while clicking to paint once. Mobile shortcut: long-press a pixel to paint once.
           </p>
           <div class="field">
             <label for="paintPaletteTarget">Paint with palette color</label>

--- a/index.html
+++ b/index.html
@@ -81,6 +81,37 @@
         <div id="paletteControls" class="palette-controls"></div>
       </section>
 
+      <section class="panel replace-panel" aria-labelledby="replace-title">
+        <div class="preview-header">
+          <h2 id="replace-title">Replace Color</h2>
+          <span id="selectionCount">No pixels selected</span>
+        </div>
+        <p id="selectionPrompt" class="hint">
+          Click any pixel in the preview grid to select its color.
+        </p>
+        <div id="selectionDetails" class="selection-details is-hidden">
+          <div class="selection-row">
+            <div id="selectionSwatch" class="selection-swatch"></div>
+            <div class="selection-meta">
+              <strong id="selectionHex">#000000</strong>
+              <span id="selectionPixels">0 pixels</span>
+            </div>
+          </div>
+          <div class="field">
+            <label for="paletteTarget">Replace with palette color</label>
+            <select id="paletteTarget"></select>
+            <button id="applyPaletteReplace" class="primary">Replace from palette</button>
+          </div>
+          <div class="field">
+            <label for="customColor">Or choose a custom color</label>
+            <div class="custom-color-row">
+              <input type="color" id="customColor" value="#ffffff" />
+              <button id="applyCustomReplace" class="ghost">Replace with picker</button>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <section class="panel export-panel" aria-labelledby="export-title">
         <h2 id="export-title">Export WLED Preset</h2>
         <div class="action-row">

--- a/index.html
+++ b/index.html
@@ -110,6 +110,31 @@
             </div>
           </div>
         </div>
+        <div class="single-paint">
+          <div class="panel-header">
+            <h3>Single Pixel Paint</h3>
+            <button id="togglePaintMode" class="ghost small" type="button">Paint mode off</button>
+          </div>
+          <p class="hint">
+            Choose a paint color, then click pixels while paint mode is on (or hold Ctrl/Cmd while clicking).
+          </p>
+          <div class="field">
+            <label for="paintPaletteTarget">Paint with palette color</label>
+            <select id="paintPaletteTarget"></select>
+          </div>
+          <div class="field">
+            <label for="paintCustomColor">Or pick a custom color</label>
+            <div class="custom-color-row">
+              <input type="color" id="paintCustomColor" value="#ff0000" />
+              <button id="setPaintCustom" class="ghost" type="button">Use custom color</button>
+            </div>
+          </div>
+          <div class="paint-status">
+            <span>Current paint color:</span>
+            <div id="paintSwatch" class="selection-swatch small"></div>
+            <strong id="paintHex">#FF0000</strong>
+          </div>
+        </div>
       </section>
 
       <section class="panel export-panel" aria-labelledby="export-title">

--- a/index.html
+++ b/index.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WLED Pixel Art Generator</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app-shell">
+      <header>
+        <h1>WLED Pixel Art Generator</h1>
+        <p class="subtitle">
+          Build pixel-art presets for your WLED matrix. Import an image or
+          existing preset, fine-tune the palette, then export ready-to-use JSON.
+        </p>
+      </header>
+
+      <section class="controls-grid">
+        <section class="panel" aria-labelledby="matrix-settings-title">
+          <div class="panel-header">
+            <h2 id="matrix-settings-title">Matrix Settings</h2>
+            <button id="resetGrid" class="ghost">Clear grid</button>
+          </div>
+          <div class="field">
+            <label for="matrixWidth">Width (pixels)</label>
+            <input type="number" id="matrixWidth" min="1" max="64" value="17" />
+          </div>
+          <div class="field">
+            <label for="matrixHeight">Height (pixels)</label>
+            <input type="number" id="matrixHeight" min="1" max="64" value="17" />
+          </div>
+          <div class="field">
+            <label for="colorCount">Palette size</label>
+            <input type="range" id="colorCount" min="2" max="32" value="8" />
+            <span id="colorCountValue">8 colors</span>
+          </div>
+          <div class="field checkbox">
+            <input type="checkbox" id="serpentineOrder" checked />
+            <label for="serpentineOrder">Serpentine wiring (boustrophedon)</label>
+          </div>
+        </section>
+
+        <section class="panel" aria-labelledby="import-title">
+          <h2 id="import-title">Import Source</h2>
+          <div class="import-group">
+            <label class="file-upload">
+              <input type="file" id="imageInput" accept="image/*" />
+              <span>Upload image</span>
+            </label>
+            <p class="hint">Images are scaled to your matrix resolution.</p>
+          </div>
+          <div class="import-group">
+            <label for="jsonInput">Paste WLED JSON preset</label>
+            <textarea id="jsonInput" rows="8" spellcheck="false" placeholder="Paste a WLED preset or previously exported JSON"></textarea>
+            <div class="action-row">
+              <button id="loadJson" class="primary">Load preset</button>
+              <button id="sampleJson" class="ghost">Sample preset</button>
+            </div>
+          </div>
+        </section>
+      </section>
+
+      <section class="status" role="status" aria-live="polite" id="statusArea">
+        Ready. Adjust settings or import an image to get started.
+      </section>
+
+      <section class="preview-wrapper" aria-labelledby="preview-title">
+        <div class="preview-header">
+          <h2 id="preview-title">Pixel Preview</h2>
+          <span id="resolutionLabel">17 × 17</span>
+        </div>
+        <div id="preview-grid" class="preview-grid" role="grid" aria-label="Pixel art preview"></div>
+      </section>
+
+      <section class="palette-wrapper" aria-labelledby="palette-title">
+        <div class="preview-header">
+          <h2 id="palette-title">Palette</h2>
+          <span id="paletteSummary">0 colors</span>
+        </div>
+        <div id="paletteControls" class="palette-controls"></div>
+      </section>
+
+      <section class="panel export-panel" aria-labelledby="export-title">
+        <h2 id="export-title">Export WLED Preset</h2>
+        <div class="action-row">
+          <button id="generateJson" class="primary">Generate JSON</button>
+          <button id="downloadJson" class="ghost" disabled>Download</button>
+        </div>
+        <textarea id="exportOutput" rows="10" readonly spellcheck="false" placeholder="Generated preset JSON will appear here"></textarea>
+      </section>
+    </main>
+
+    <canvas id="workCanvas" width="17" height="17" hidden></canvas>
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,278 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0f172a;
+  --panel: #1e293b;
+  --panel-light: #ffffff;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --accent: #0ea5e9;
+  --accent-strong: #0284c7;
+  --border: rgba(255, 255, 255, 0.08);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(14, 165, 233, 0.15), transparent 45%), var(--bg);
+  color: var(--text);
+  display: flex;
+  justify-content: center;
+  padding: 2.5rem 1.5rem 4rem;
+}
+
+.app-shell {
+  width: min(1200px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+header h1 {
+  margin: 0 0 0.25rem;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--muted);
+  max-width: 70ch;
+}
+
+.controls-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  box-shadow: 0 12px 35px rgba(0, 0, 0, 0.35);
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-top: 0.75rem;
+}
+
+.field input,
+.field textarea,
+textarea {
+  border-radius: 0.6rem;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--text);
+  padding: 0.55rem 0.75rem;
+  font-size: 1rem;
+}
+
+.field.checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+input[type="number"] {
+  max-width: 110px;
+}
+
+input[type="range"] {
+  accent-color: var(--accent);
+}
+
+.file-upload {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed rgba(148, 163, 184, 0.6);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  gap: 0.5rem;
+  transition: border 0.2s ease, color 0.2s ease;
+}
+
+.file-upload input {
+  display: none;
+}
+
+.file-upload span {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.file-upload:hover {
+  border-color: var(--accent);
+}
+
+.import-group {
+  margin-top: 1rem;
+}
+
+.hint {
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin: 0.35rem 0 0;
+}
+
+textarea {
+  resize: vertical;
+}
+
+.action-row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 0.75rem;
+}
+
+button {
+  border: none;
+  border-radius: 0.65rem;
+  padding: 0.6rem 1.1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+button.primary {
+  background: var(--accent);
+  color: #0f172a;
+  box-shadow: 0 5px 25px rgba(14, 165, 233, 0.35);
+}
+
+button.primary:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+button.ghost {
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.status {
+  padding: 0.75rem 1rem;
+  border-radius: 0.8rem;
+  background: rgba(14, 165, 233, 0.12);
+  border: 1px solid rgba(14, 165, 233, 0.25);
+  font-size: 0.95rem;
+}
+.status[data-level="warn"] {
+  background: rgba(234, 179, 8, 0.15);
+  border-color: rgba(234, 179, 8, 0.35);
+}
+.status[data-level="error"] {
+  background: rgba(248, 113, 113, 0.18);
+  border-color: rgba(248, 113, 113, 0.45);
+}
+
+.preview-wrapper,
+.palette-wrapper,
+.export-panel {
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.45);
+}
+
+.preview-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.preview-grid {
+  display: grid;
+  gap: 2px;
+  width: min(520px, 100%);
+  aspect-ratio: 1 / 1;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 0.4rem;
+  background: #020617;
+}
+
+.pixel {
+  border-radius: 0.15rem;
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(15, 23, 42, 0.25);
+}
+
+.pixel span {
+  position: absolute;
+  font-size: 0.55rem;
+  color: rgba(15, 23, 42, 0.4);
+  bottom: 0.12rem;
+  right: 0.18rem;
+  font-weight: 600;
+}
+
+.palette-controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.palette-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.palette-chip input[type="color"] {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  background: none;
+  padding: 0;
+}
+
+.palette-meta {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+
+.palette-meta span {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 1.25rem 0.75rem 2.5rem;
+  }
+
+  .preview-grid {
+    width: 100%;
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -222,6 +222,7 @@ button.ghost {
   position: relative;
   overflow: hidden;
   border: 1px solid rgba(15, 23, 42, 0.25);
+  cursor: pointer;
 }
 
 .pixel span {
@@ -231,6 +232,10 @@ button.ghost {
   bottom: 0.12rem;
   right: 0.18rem;
   font-weight: 600;
+}
+.pixel.selected {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 
 .palette-controls {
@@ -265,6 +270,58 @@ button.ghost {
 .palette-meta span {
   font-size: 0.85rem;
   color: var(--muted);
+}
+
+.replace-panel .field button {
+  margin-top: 0.5rem;
+}
+
+.selection-details {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.selection-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.selection-swatch {
+  width: 48px;
+  height: 48px;
+  border-radius: 0.6rem;
+  border: 2px solid rgba(148, 163, 184, 0.4);
+  background: #000;
+}
+
+.selection-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.selection-meta strong {
+  font-size: 1.05rem;
+}
+
+.custom-color-row {
+  display: flex;
+  gap: 0.65rem;
+  align-items: center;
+}
+
+.custom-color-row input[type="color"] {
+  width: 3rem;
+  height: 3rem;
+  padding: 0;
+  border: none;
+  background: transparent;
+}
+
+.is-hidden {
+  display: none !important;
 }
 
 @media (max-width: 720px) {

--- a/styles.css
+++ b/styles.css
@@ -173,6 +173,17 @@ button.ghost {
   border: 1px solid rgba(148, 163, 184, 0.3);
 }
 
+button.ghost.is-active {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: rgba(14, 165, 233, 0.12);
+}
+
+button.small {
+  padding: 0.4rem 0.9rem;
+  font-size: 0.9rem;
+}
+
 .status {
   padding: 0.75rem 1rem;
   border-radius: 0.8rem;
@@ -295,6 +306,10 @@ button.ghost {
   border: 2px solid rgba(148, 163, 184, 0.4);
   background: #000;
 }
+.selection-swatch.small {
+  width: 36px;
+  height: 36px;
+}
 
 .selection-meta {
   display: flex;
@@ -318,6 +333,28 @@ button.ghost {
   padding: 0;
   border: none;
   background: transparent;
+}
+
+.single-paint {
+  margin-top: 1.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.paint-status {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.paint-status strong {
+  color: var(--text);
+  font-size: 1rem;
 }
 
 .is-hidden {


### PR DESCRIPTION
Add a WLED pixel art preset generator webpage to create WLED matrix presets.

This enables users to import images or existing WLED JSON, customize matrix dimensions, quantize colors into a palette, preview the pixel grid, and export a WLED preset JSON with serpentine wiring awareness.

---
<a href="https://cursor.com/background-agent?bcId=bc-d306306e-812d-4c42-9a6c-8b9a63796caf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d306306e-812d-4c42-9a6c-8b9a63796caf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

